### PR TITLE
Fragment result status

### DIFF
--- a/src/client-electron/renderer/pages/CalibrateFragment.tsx
+++ b/src/client-electron/renderer/pages/CalibrateFragment.tsx
@@ -1,7 +1,6 @@
 import { UpdateSettingsAction } from '@/client-electron/actions';
 import { HistoryEntry, TestThresholdData } from '@/client-electron/common';
 import { BreachProtocolFragmentResults, FragmentId } from '@/core';
-import { BreachProtocolFragmentStatus } from '@/core/ocr/base';
 import { FC, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { rendererAsyncRequestDispatcher as asyncRequest } from '../../common';

--- a/src/client-electron/renderer/pages/CalibrateFragment.tsx
+++ b/src/client-electron/renderer/pages/CalibrateFragment.tsx
@@ -57,7 +57,6 @@ export const CalibrateFragment: FC<CalibrateFragmentProps> = ({ entry }) => {
   const isBufferSize = fragmentId === 'bufferSize';
   const isExperimental =
     entry.settings.experimentalBufferSizeRecognition && isBufferSize;
-  const isValid = testResult.status === BreachProtocolFragmentStatus.Valid;
   const [loading, setLoading] = useState<boolean>(false);
   const [showBoxes, setShowBoxes] = useState(false);
   const [testThreshold, setTestThreshold] = useState<number>(
@@ -123,7 +122,7 @@ export const CalibrateFragment: FC<CalibrateFragmentProps> = ({ entry }) => {
           </Field>
           <FlatButton
             type="submit"
-            disabled={!isValid || isExperimental}
+            disabled={!testResult.isValid || isExperimental}
             color="accent"
             style={{ alignSelf: 'flex-end' }}
           >

--- a/src/client-electron/renderer/pages/CalibrateFragment.tsx
+++ b/src/client-electron/renderer/pages/CalibrateFragment.tsx
@@ -1,10 +1,11 @@
 import { UpdateSettingsAction } from '@/client-electron/actions';
 import { HistoryEntry, TestThresholdData } from '@/client-electron/common';
 import { BreachProtocolFragmentResults, FragmentId } from '@/core';
+import { BreachProtocolFragmentStatus } from '@/core/ocr/base';
 import { FC, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { rendererAsyncRequestDispatcher as asyncRequest } from '../../common';
-import { fromCamelCase, dispatch } from '../common';
+import { dispatch, fromCamelCase } from '../common';
 import {
   Col,
   Field,
@@ -56,6 +57,7 @@ export const CalibrateFragment: FC<CalibrateFragmentProps> = ({ entry }) => {
   const isBufferSize = fragmentId === 'bufferSize';
   const isExperimental =
     entry.settings.experimentalBufferSizeRecognition && isBufferSize;
+  const isValid = testResult.status === BreachProtocolFragmentStatus.Valid;
   const [loading, setLoading] = useState<boolean>(false);
   const [showBoxes, setShowBoxes] = useState(false);
   const [testThreshold, setTestThreshold] = useState<number>(
@@ -121,7 +123,7 @@ export const CalibrateFragment: FC<CalibrateFragmentProps> = ({ entry }) => {
           </Field>
           <FlatButton
             type="submit"
-            disabled={!testResult.isValid || isExperimental}
+            disabled={!isValid || isExperimental}
             color="accent"
             style={{ alignSelf: 'flex-end' }}
           >

--- a/src/core/ocr/base.ts
+++ b/src/core/ocr/base.ts
@@ -93,7 +93,7 @@ export abstract class BreachProtocolFragment<
     threshold?: number
   ): Promise<BreachProtocolFragmentResult<TData, TId>>;
 
-  abstract getStatus(data: TData): BreachProtocolFragmentStatus;
+  abstract getStatus(rawData: TData): BreachProtocolFragmentStatus;
 
   private getBaseResult(rawData: TData): BreachProtocolFragmentResultBase<TId> {
     const { id, boundingBox } = this;

--- a/src/core/ocr/base.ts
+++ b/src/core/ocr/base.ts
@@ -24,10 +24,19 @@ export interface BreachProtocolSource {
   boxes: Tesseract.Bbox[];
 }
 
+export enum FragmentResultStatus {
+  VALID,
+  INVALID_SYMBOLS,
+  // This is not breach protocol screenshot or threshold is completly off.
+  INVALID_SIZE,
+  INVALID_CONTROL_GROUPS,
+}
+
 interface BreachProtocolFragmentResultBase<TId extends FragmentId> {
   readonly boundingBox: BreachProtocolFragmentBoundingBox;
   readonly isValid: boolean;
   readonly id: TId;
+  readonly status: FragmentResultStatus;
 }
 
 export interface BreachProtocolFragmentResult<

--- a/src/core/ocr/buffer-size-trim.ts
+++ b/src/core/ocr/buffer-size-trim.ts
@@ -1,35 +1,11 @@
-import { Point } from '@/common';
-import { BufferSize, BUFFER_SIZE_MAX, BUFFER_SIZE_MIN } from '../common';
-import { BreachProtocolFragment } from './base';
+import { BufferSize } from '../common';
+import { BreachProtocolBufferSizeBase } from './base';
 import { BreachProtocolBufferSizeFragmentResult } from './buffer-size';
 
 export class BreachProtocolBufferSizeTrimFragment<
   TImage
-> extends BreachProtocolFragment<BufferSize, TImage, 'bufferSize'> {
-  readonly id = 'bufferSize';
-
-  readonly p1 = new Point(0.42, 0.167);
-
-  readonly p2 = new Point(0.8, 0.225);
-
-  readonly boundingBox = this.getFragmentBoundingBox();
-
-  readonly fragment = this.container.processBufferSizeFragment(
-    this.boundingBox
-  );
-
-  /** Percentage that padding in buffer box takes. */
-  private readonly padding = 0.00937;
-
-  /** Percentage that buffer square takes. */
-  private readonly square = 0.0164;
-
-  /** Percentage that gap between buffer squares takes. */
-  private readonly gap = 0.00546;
-
-  isValid(n: number) {
-    return Number.isInteger(n) && n >= BUFFER_SIZE_MIN && n <= BUFFER_SIZE_MAX;
-  }
+> extends BreachProtocolBufferSizeBase<TImage> {
+  override readonly fragment = this.container.processBufferSizeFragment(this.boundingBox);
 
   // Ensure compatibility with current api.
   async recognize(

--- a/src/core/ocr/daemons.ts
+++ b/src/core/ocr/daemons.ts
@@ -3,6 +3,7 @@ import { DaemonsRawData } from '../common';
 import {
   BreachProtocolFragmentResult,
   BreachProtocolOCRFragment,
+  BreachProtocolFragmentStatus,
 } from './base';
 
 export type BreachProtocolDaemonsFragmentResult = BreachProtocolFragmentResult<
@@ -35,9 +36,19 @@ export class BreachProtocolDaemonsFragment<
     return lines.map((l) => this.parseLine(l));
   }
 
-  isValid(rawData: DaemonsRawData) {
-    const isCorrectSize = rawData.every((d) => d.length <= 5);
+  private isCorrectSize(rawData: DaemonsRawData) {
+    return rawData.every((d) => d.length <= 5);
+  }
 
-    return this.validateSymbols(rawData.flat()) && isCorrectSize;
+  getStatus(rawData: DaemonsRawData) {
+    if (!this.isCorrectSize(rawData)) {
+      return BreachProtocolFragmentStatus.InvalidSize;
+    }
+
+    if (!this.validateSymbols(rawData.flat())) {
+      return BreachProtocolFragmentStatus.InvalidSymbols;
+    }
+
+    return BreachProtocolFragmentStatus.Valid;
   }
 }

--- a/src/core/ocr/daemons.ts
+++ b/src/core/ocr/daemons.ts
@@ -37,7 +37,7 @@ export class BreachProtocolDaemonsFragment<
   }
 
   private isCorrectSize(rawData: DaemonsRawData) {
-    return rawData.every((d) => d.length <= 5);
+    return rawData.every(({ length }) => length && length <= 5);
   }
 
   getStatus(rawData: DaemonsRawData) {

--- a/src/core/ocr/grid.ts
+++ b/src/core/ocr/grid.ts
@@ -3,6 +3,7 @@ import { GridRawData } from '../common';
 import {
   BreachProtocolFragmentResult,
   BreachProtocolOCRFragment,
+  BreachProtocolFragmentStatus,
 } from './base';
 
 export type BreachProtocolGridFragmentResult = BreachProtocolFragmentResult<
@@ -39,7 +40,15 @@ export class BreachProtocolGridFragment<
     return n > 0 && Math.sqrt(n) % 1 === 0;
   }
 
-  isValid(rawData: GridRawData) {
-    return this.validateSymbols(rawData) && this.isSquare(rawData.length);
+  getStatus(rawData: GridRawData) {
+    if (!this.isSquare(rawData.length)) {
+      return BreachProtocolFragmentStatus.InvalidSize;
+    }
+
+    if (!this.validateSymbols(rawData)) {
+      return BreachProtocolFragmentStatus.InvalidSymbols;
+    }
+
+    return BreachProtocolFragmentStatus.Valid;
   }
 }

--- a/src/core/ocr/ocr.test.ts
+++ b/src/core/ocr/ocr.test.ts
@@ -2,7 +2,11 @@ import path from 'path';
 import sharp from 'sharp';
 import registry from '../../bp-registry/registry.json';
 import { BufferSize, DaemonsRawData, GridRawData } from '../common';
-import { BreachProtocolOCRFragment, FragmentId } from './base';
+import {
+  BreachProtocolOCRFragment,
+  FragmentId,
+  BreachProtocolFragmentStatus,
+} from './base';
 import { BreachProtocolBufferSizeFragment } from './buffer-size';
 import { BreachProtocolBufferSizeTrimFragment } from './buffer-size-trim';
 import { BreachProtocolDaemonsFragment } from './daemons';
@@ -113,6 +117,7 @@ describe('raw data validation', () => {
     ['FF', '55'],
   ];
   const bufferSize: BufferSize = 6;
+  const valid = BreachProtocolFragmentStatus.Valid;
 
   it('should pass it if data is valid', () => {
     const gridFragment = new BreachProtocolGridFragment(testContainer);
@@ -121,9 +126,9 @@ describe('raw data validation', () => {
       testContainer
     );
 
-    expect(gridFragment.isValid(grid)).toBeTruthy();
-    expect(daemonsFragment.isValid(daemons)).toBeTruthy();
-    expect(bufferSizeFragment.isValid(bufferSize)).toBeTruthy();
+    expect(gridFragment.getStatus(grid)).toBe(valid);
+    expect(daemonsFragment.getStatus(daemons)).toBe(valid);
+    expect(bufferSizeFragment.getStatus(bufferSize)).toBe(valid);
   });
 
   it('should throw an error if grid is invalid', () => {
@@ -137,7 +142,7 @@ describe('raw data validation', () => {
     ] as GridRawData[];
 
     invalidGrids.forEach((grid) => {
-      expect(fragment.isValid(grid)).toBeFalsy();
+      expect(fragment.getStatus(grid)).not.toBe(valid);
     });
   });
 
@@ -151,7 +156,7 @@ describe('raw data validation', () => {
     ] as DaemonsRawData[];
 
     invalidDaemons.forEach((daemons) => {
-      expect(fragment.isValid(daemons)).toBeFalsy();
+      expect(fragment.getStatus(daemons)).not.toBe(valid);
     });
   });
 
@@ -160,7 +165,7 @@ describe('raw data validation', () => {
     const invalidBufferSizes = [NaN, 3, 10, 2 * Math.PI] as BufferSize[];
 
     invalidBufferSizes.forEach((bufferSize) => {
-      expect(fragment.isValid(bufferSize)).toBeFalsy();
+      expect(fragment.getStatus(bufferSize)).not.toBe(valid);
     });
   });
 });


### PR DESCRIPTION
`boolean` is not good enough to handle fragment results. Sometimes reason why result in not valid is required. For example when screenshot in not on correct monitior, there is no need to store rawData.

TODO:

- [x] remove isValid and add getStatus
- [x] update code to use status instead of isValid
- [x] make sure fragments set correct enum values.

this should be merged **before** #109 